### PR TITLE
Update PassTemplates.lua

### DIFF
--- a/BetterMelk/scripts/mods/BetterMelk/PassTemplates.lua
+++ b/BetterMelk/scripts/mods/BetterMelk/PassTemplates.lua
@@ -3,7 +3,7 @@ local mod = get_mod("BetterMelk")
 local ColorUtilities = require("scripts/utilities/ui/colors")
 local UIFontSettings = require("scripts/managers/ui/ui_font_settings")
 
-local CONTRACTS_TEXT_OFFSET = { 173, 40, 10 }
+local CONTRACTS_TEXT_OFFSET = { 400, 30, 10 }
 
 local contracts_text_style = table.clone(UIFontSettings.body_small)
 contracts_text_style.text_horizontal_alignment = "left"


### PR DESCRIPTION
Changed the offset of the numbers so that they do not overlap when the player's title is displaying. Moved it to the right and a little higher.
![screenshot_20240419_132214](https://github.com/ItsAlxl/darktide-mods/assets/21146468/7d578f93-9d01-4d66-b760-c92b5ef81b1b)
![screenshot_20240419_131027](https://github.com/ItsAlxl/darktide-mods/assets/21146468/7989bee7-ea3d-4bc2-9f8a-b3fd20fd1d9a)

