### PR TITLE
Fix a bug when holding click before swapping into the gun

### DIFF
--- a/FullAuto/scripts/mods/FullAuto/FullAuto.lua
+++ b/FullAuto/scripts/mods/FullAuto/FullAuto.lua
@@ -274,6 +274,9 @@ local _input_action_hook = function(func, self, action_name)
 				is_firing = true
 				next_autofire = -1
 			end
+            if action_name == "action_one_hold" then
+                is_firing = true
+            end
 			if action_name == "action_one_release" then
 				is_firing = false
 			end


### PR DESCRIPTION
FullAuto for single-fire weapons doesn't seem to do auto fire when you hold click before swapping in to the gun
[video](https://cdn.discordapp.com/attachments/1086917715110940692/1266020252186185822/2024-07-25_20-05-44.mp4?ex=66a59afd&is=66a4497d&hm=d46c843d6b25fc635b60e50f1093920f06fd896c5268b490713d385d79d9d8c2&)
this is vanilla behavior of auto guns
[video](https://cdn.discordapp.com/attachments/1086917715110940692/1266020502422556814/2024-07-25_20-03-25.mp4?ex=66a59b39&is=66a449b9&hm=5b80c3e13bd79e84d67093614d83e92f97fc0fc58ca706beef29bea92c7fc92e&)