### PR TITLE
KeepSwinging: fix for hellbore lasgun bayonet special since patch 1.5.0

### DIFF
--- a/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging.lua
+++ b/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging.lua
@@ -1,7 +1,7 @@
 local mod = get_mod("KeepSwinging")
 
 local SWING_DELAY_FRAMES = 10
-local RELEASE_DELAY_FRAMES = 1
+local RELEASE_DELAY_FRAMES = 2
 local VALID_MELEE_SPECIAL_TYPES = { "special_attack", "melee_hand" }
 local VALID_RANGED_SPECIAL_TYPES = { "melee", "melee_hand" }
 local ACTION_SETS = {


### PR DESCRIPTION
For some reason, auto swinging with bayonet doesn't work since Unlocked&Loaded. Increasing the release delay frames does the trick