### PR TITLE
Added Burst Mode to Keepswinging,

### DIFF
--- a/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_data.lua
+++ b/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_data.lua
@@ -29,6 +29,15 @@ return {
 						function_name   = "_toggle_swinging",
 					},
 					{
+						setting_id      = "burst_keybind",
+						type            = "keybind",
+						default_value   = {},
+						keybind_global  = false,
+						keybind_trigger = "pressed",
+						keybind_type    = "function_call",
+						function_name   = "_init_burst_swinging",
+					},
+					{
 						setting_id    = "default_mode",
 						type          = "checkbox",
 						default_value = false,
@@ -37,6 +46,12 @@ return {
 						setting_id    = "as_modifier",
 						type          = "checkbox",
 						default_value = false,
+					},
+					{
+						setting_id    = "burst_length",
+						type          = "numeric",
+						default_value = 6,
+						range         = { 3, 15 },
 					},
 				}
 			},

--- a/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
+++ b/KeepSwinging/scripts/mods/KeepSwinging/KeepSwinging_localization.lua
@@ -11,6 +11,22 @@ return {
 		en = "Enable Auto-Swing (Toggle)",
 		["zh-cn"] = "启用自动攻击（切换）",
 	},
+	burst_keybind = {
+		en = "Burst Mode Keybind",
+		["zh-cn"] = "",
+	},
+	burst_keybind_description = {
+		en = "Burst Mode starts an auto swing sequence, that stops after the configured Burst Length (see below)",
+		["zh-cn"] = "",
+	},
+	burst_length = {
+		en = "Burst Length",
+		["zh-cn"] = "",
+	},
+	burst_length_description = {
+		en = "This determines how long the Burst Mode will go on before stopping. Experiment to see which value works for you.",
+		["zh-cn"] = "",
+	},
 	as_modifier = {
 		en = "Modifier Mode",
 		["zh-cn"] = "修改模式",


### PR DESCRIPTION
So I commented on NexusMods a couple days ago how I implemented a Burst Mode to KeepSwinging, and here it is.

A couple of issues that I couldn't easily resolve:

- If 'Default to Auto-Swing' is enabled in the Mod Options, the player character will go into autoswing mode immediately after loading into a mission / Psykhanium. The player must then cancel this by weapon swapping or tapping the burst key, which will then stop the auto attacking immediately or after a while, respectively.

- Not sure about all the edges cases w regards to canceling states since I didn't touch them. Didn't run into any issues during gameplay, though.

- The holy grail would be seamless integration into the main attack key (typically LMB), but this would require some reconfiguration and further development (maybe a Burst-As-Modifier mode). You can actually re-map the Burst Mode key into LMB and it will work quite well but you typically must do this by loading into a mission and initializing a burst with some other key, then changing it to LMB. Leaving it mapped to LMB over game restart seem to result in either impossible-to-stop or impossible-to-start depending on whether 'Default to Auto-Swing' is enabled. Also when mapped to LMB, heavy attacks will currently continue with the burst sequence, which isn't ideal.

